### PR TITLE
Fix E302 on pep8

### DIFF
--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -3,6 +3,7 @@ import time
 import threading
 import pyjoycon.device as d
 
+
 class JoyCon:
     VENDOR_ID = 0x057E
     L_PRODUCT_ID = 0x2006


### PR DESCRIPTION
PEP8の警告に対処しました。
`E302 expected 2 blank lines, found 1`