### PR TITLE
CIを追加

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,23 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+
+    - name: Install the package
+      run: pip install .
+
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --extend-ignore=E501 --show-source --statistics


### PR DESCRIPTION
GitHub Actionsでコミットとプルリクエストをチェックするようにしました。
現状ではパッケージのテストがまだないので、次の2つだけをチェックしています。
- `pip`で問題なくインストールできるか
- `flake8`によるリントが通るか

なお、`flake8`によるリントでは現状E501(`line too long`)を無視するようにしています。
(すぐに直せるものではなさそうだったので)

(作成参考:[actions/starter-workflows](https://github.com/actions/starter-workflows/blob/master/ci/python-package.yml))
