### PR TITLE
Add support for `hid`, expand functionality

### DIFF
--- a/pyjoycon/device.py
+++ b/pyjoycon/device.py
@@ -22,7 +22,7 @@ def get_device_ids():
 
     for device in devices:
         prod = device['product_string']
-        if "Joy-Con" in prod:
+        if prod and "Joy-Con" in prod:
             print(prod)
             print(f"product_id is {device['product_id']}")
             print(f"vendor_id is {device['vendor_id']}")

--- a/pyjoycon/device.py
+++ b/pyjoycon/device.py
@@ -1,7 +1,7 @@
 import hid
 
 
-def get_device_ids():
+def get_device_ids(debug=False):
     """
     returns dictionary of id info
 
@@ -23,9 +23,10 @@ def get_device_ids():
     for device in devices:
         prod = device['product_string']
         if prod and "Joy-Con" in prod:
-            print(prod)
-            print(f"product_id is {device['product_id']}")
-            print(f"vendor_id is {device['vendor_id']}")
+            if debug:
+                print(prod)
+                print(f"product_id is {device['product_id']}")
+                print(f"vendor_id is {device['vendor_id']}")
 
             if "R" in prod:
                 R["product"] = device['product_id']
@@ -36,21 +37,21 @@ def get_device_ids():
     return {"R": R, "L": L}
 
 
-def get_ids(lr):
+def get_ids(lr, **kw):
     """
     returns tuple of `(vendor_id, product_id)`
 
     arg: lr : str : put `R` or `L`
     """
-    ids = get_device_ids()
+    ids = get_device_ids(**kw)
     return (ids[lr]["vendor"], ids[lr]["product"])
 
 
-def get_R_ids():
+def get_R_ids(**kw):
     """returns tuple of `(vendor_id, product_id)`"""
-    return get_ids("R")
+    return get_ids("R", **kw)
 
 
-def get_L_ids():
+def get_L_ids(**kw):
     """returns tuple of `(vendor_id, product_id)`"""
-    return get_ids("L")
+    return get_ids("L", **kw)

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -89,7 +89,8 @@ class JoyCon:
         # Change format of input report
         self._write_output_report(b'\x01', b'\x03', b'\x30')
 
-    def _to_int16le_from_2bytes(self, hbytebe, lbytebe):
+    @staticmethod
+    def _to_int16le_from_2bytes(hbytebe, lbytebe):
         uint16le = (lbytebe << 8) | hbytebe
         int16le = uint16le if uint16le < 32768 else uint16le - 65536
         return int16le

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -26,6 +26,7 @@ class JoyCon:
         # setup internal state
         self._input_hooks = []
         self._joycon_device = None
+        self._input_report = bytes(self._INPUT_REPORT_SIZE)
         self._packet_number = 0
         self._PRODUCT_ID = product_id
         self._SERIAL_NUMBER = serial
@@ -40,7 +41,7 @@ class JoyCon:
         self._joycon_device = self._open(vendor_id, product_id, serial=None)
         self._setup_sensors()
 
-        self._input_report = bytes(self._INPUT_REPORT_SIZE)
+        # start talking with the joycon in a daemon thread
         self._update_input_report_thread = threading.Thread(
             target=self._update_input_report)
         self._update_input_report_thread.setDaemon(True)

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -23,7 +23,7 @@ class JoyCon:
         if vendor_id != self.VENDOR_ID:
             raise ValueError('vendor_id is invalid')
 
-        if product_id not in [self.L_PRODUCT_ID, self.R_PRODUCT_ID]:
+        if product_id not in (self.L_PRODUCT_ID, self.R_PRODUCT_ID):
             raise ValueError('product_id is invalid')
 
         self._joycon_device = None
@@ -185,40 +185,40 @@ class JoyCon:
         return self._get_nbit_from_input_report(10, 4, 4) | (self._get_nbit_from_input_report(11, 0, 8) << 4)
 
     def get_accel_x(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return (self._to_int16le_from_2bytes(self._get_nbit_from_input_report(13 + sample_idx * 12, 0, 8),
                                              self._get_nbit_from_input_report(14 + sample_idx * 12, 0, 8))
                 - (self._L_ACCEL_OFFSET_X if self.is_left() else self._R_ACCEL_OFFSET_X))
 
     def get_accel_y(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return (self._to_int16le_from_2bytes(self._get_nbit_from_input_report(15 + sample_idx * 12, 0, 8),
                                              self._get_nbit_from_input_report(16 + sample_idx * 12, 0, 8))
                 - (self._L_ACCEL_OFFSET_Y if self.is_left() else self._R_ACCEL_OFFSET_Y))
 
     def get_accel_z(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return (self._to_int16le_from_2bytes(self._get_nbit_from_input_report(17 + sample_idx * 12, 0, 8),
                                              self._get_nbit_from_input_report(18 + sample_idx * 12, 0, 8))
                 - (self._L_ACCEL_OFFSET_Z if self.is_left() else self._R_ACCEL_OFFSET_Z))
 
     def get_gyro_x(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return self._to_int16le_from_2bytes(self._get_nbit_from_input_report(19 + sample_idx * 12, 0, 8),
                                             self._get_nbit_from_input_report(20 + sample_idx * 12, 0, 8))
 
     def get_gyro_y(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return self._to_int16le_from_2bytes(self._get_nbit_from_input_report(21 + sample_idx * 12, 0, 8),
                                             self._get_nbit_from_input_report(22 + sample_idx * 12, 0, 8))
 
     def get_gyro_z(self, sample_idx=0):
-        if sample_idx not in [0, 1, 2]:
+        if sample_idx not in (0, 1, 2):
             raise IndexError('sample_idx should be between 0 and 2')
         return self._to_int16le_from_2bytes(self._get_nbit_from_input_report(23 + sample_idx * 12, 0, 8),
                                             self._get_nbit_from_input_report(24 + sample_idx * 12, 0, 8))

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -23,6 +23,8 @@ class JoyCon:
         if product_id not in (self.L_PRODUCT_ID, self.R_PRODUCT_ID):
             raise ValueError('product_id is invalid')
 
+        # setup internal state
+        self._input_hooks = []
         self._joycon_device = None
         self._packet_number = 0
         self._PRODUCT_ID = product_id
@@ -75,6 +77,8 @@ class JoyCon:
     def _update_input_report(self):
         while True:
             self._input_report = self._read_input_report()
+            for callback in self._input_hooks:
+                callback(self)
 
     def _setup_sensors(self):
         # Enable 6 axis sensors
@@ -104,6 +108,10 @@ class JoyCon:
         self._ACCEL_OFFSET_X = offset_xyz[0]
         self._ACCEL_OFFSET_Y = offset_xyz[1]
         self._ACCEL_OFFSET_Z = offset_xyz[2]
+
+    def register_update_hook(self, callback):
+        self._input_hooks.append(callback)
+        return callback # this makes it so you could use it as a decorator
 
     def is_left(self):
         return self._PRODUCT_ID == self.L_PRODUCT_ID

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -1,7 +1,6 @@
 import hid
 import time
 import threading
-import pyjoycon.device as d
 
 
 class JoyCon:
@@ -296,6 +295,7 @@ class JoyCon:
 
 
 if __name__ == '__main__':
+    import pyjoycon.device as d
     ids = d.get_L_ids() if None not in d.get_L_ids() else d.get_R_ids()
 
     if None not in ids:

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -16,7 +16,7 @@ class JoyCon:
     _INPUT_REPORT_PERIOD = 1.0 / 60.0
     _RUMBLE_DATA = b'\x00\x01\x40\x40\x00\x01\x40\x40'
 
-    def __init__(self, vendor_id: int, product_id: int, serial: str=None):
+    def __init__(self, vendor_id: int, product_id: int, serial: str = None):
         if vendor_id != self.VENDOR_ID:
             raise ValueError('vendor_id is invalid')
 
@@ -113,7 +113,7 @@ class JoyCon:
 
     def register_update_hook(self, callback):
         self._input_hooks.append(callback)
-        return callback # this makes it so you could use it as a decorator
+        return callback  # this makes it so you could use it as a decorator
 
     def is_left(self):
         return self._PRODUCT_ID == self.L_PRODUCT_ID

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -18,7 +18,7 @@ class JoyCon:
     _INPUT_REPORT_FREQ = 1.0 / 60.0
     _RUMBLE_DATA = b'\x00\x01\x40\x40\x00\x01\x40\x40'
 
-    def __init__(self, vendor_id, product_id):
+    def __init__(self, vendor_id: int, product_id: int):
         if vendor_id != self.VENDOR_ID:
             raise ValueError('vendor_id is invalid')
 
@@ -222,7 +222,7 @@ class JoyCon:
         return self._to_int16le_from_2bytes(self._get_nbit_from_input_report(23 + sample_idx * 12, 0, 8),
                                             self._get_nbit_from_input_report(24 + sample_idx * 12, 0, 8))
 
-    def get_status(self):
+    def get_status(self) -> dict:
         return {
             "battery": {
                 "charging": self.get_battery_charging(),
@@ -281,15 +281,15 @@ class JoyCon:
             },
         }
 
-    def set_player_lamp_on(self, on_pattern):
+    def set_player_lamp_on(self, on_pattern: int):
         self._write_output_report(
             b'\x01', b'\x30', (on_pattern & 0xF).to_bytes(1, byteorder='big'))
 
-    def set_player_lamp_flashing(self, flashing_pattern):
+    def set_player_lamp_flashing(self, flashing_pattern: int):
         self._write_output_report(
             b'\x01', b'\x30', ((flashing_pattern & 0xF) << 4).to_bytes(1, byteorder='big'))
 
-    def set_player_lamp(self, pattern):
+    def set_player_lamp(self, pattern: int):
         self._write_output_report(
             b'\x01', b'\x30', pattern.to_bytes(1, byteorder='big'))
 

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -50,7 +50,8 @@ class JoyCon:
     def _open(self, vendor_id, product_id, serial):
         try:
             if hasattr(hid, "device"):  # hidapi
-                _joycon_device = hid.device(vendor_id, product_id, serial)
+                _joycon_device = hid.device()
+                _joycon_device.open(vendor_id, product_id, serial)
             elif hasattr(hid, "Device"):  # hid
                 _joycon_device = hid.Device(vendor_id, product_id, serial)
             else:

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -16,7 +16,7 @@ class JoyCon:
     _INPUT_REPORT_PERIOD = 1.0 / 60.0
     _RUMBLE_DATA = b'\x00\x01\x40\x40\x00\x01\x40\x40'
 
-    def __init__(self, vendor_id: int, product_id: int):
+    def __init__(self, vendor_id: int, product_id: int, serial: str=None):
         if vendor_id != self.VENDOR_ID:
             raise ValueError('vendor_id is invalid')
 
@@ -24,8 +24,9 @@ class JoyCon:
             raise ValueError('product_id is invalid')
 
         self._joycon_device = None
-        self._PRODUCT_ID = product_id
         self._packet_number = 0
+        self._PRODUCT_ID = product_id
+        self._SERIAL_NUMBER = serial
         if self.is_left():
             self.set_accel_callibration(self._PRESET_L_ACCEL_OFFSET)
             self.set_gyro_callibration(self._PRESET_L_GYRO_OFFSET)
@@ -34,7 +35,7 @@ class JoyCon:
             self.set_gyro_callibration(self._PRESET_R_GYRO_OFFSET)
 
         # connect to joycon
-        self._joycon_device = self._open(vendor_id, product_id)
+        self._joycon_device = self._open(vendor_id, product_id, serial=None)
         self._setup_sensors()
 
         self._input_report = bytes(self._INPUT_REPORT_SIZE)
@@ -43,12 +44,12 @@ class JoyCon:
         self._update_input_report_thread.setDaemon(True)
         self._update_input_report_thread.start()
 
-    def _open(self, vendor_id, product_id):
+    def _open(self, vendor_id, product_id, serial):
         try:
             if hasattr(hid, "device"):  # hidapi
-                _joycon_device = hid.device(vendor_id, product_id)
+                _joycon_device = hid.device(vendor_id, product_id, serial)
             elif hasattr(hid, "Device"):  # hid
-                _joycon_device = hid.Device(vendor_id, product_id)
+                _joycon_device = hid.Device(vendor_id, product_id, serial)
             else:
                 raise Exception("Implementation of hid is not recognized!")
         except IOError:

--- a/pyjoycon/joycon.py
+++ b/pyjoycon/joycon.py
@@ -54,8 +54,8 @@ class JoyCon:
                 _joycon_device = hid.Device(vendor_id, product_id, serial)
             else:
                 raise Exception("Implementation of hid is not recognized!")
-        except IOError:
-            raise IOError('joycon connect failed')
+        except IOError as e:
+            raise IOError('joycon connect failed') from e
         return _joycon_device
 
     def _close(self):


### PR DESCRIPTION
This PR adds the following:
- Support for the `hid` module alongside `hidapi`
- Add support for registering callback hooks for use with IME data
  
  This data should be read without a background thread mucking about. Therefore the callbacks are run in the daemon thread.
- Add ability for user to configure the accelerator offset, add support for gyro offset
- Add ability to silence output to stdout from `get_device_ids`, enabled by default
- Add some type hints
- Multiple speedups
