### PR TITLE
Remove product string check, to fix a problem on Windows

### DIFF
--- a/pyjoycon/device.py
+++ b/pyjoycon/device.py
@@ -22,8 +22,6 @@ def get_device_ids(debug=False):
             continue
         if not product_string:
             continue
-        if not product_string.startswith("Joy-Con"):
-            continue
 
         out.append((vendor_id, product_id, serial))
 


### PR DESCRIPTION
This PR fixes a problem in finding a Joy-Con on Windows environment.

On Windows (at least on my Windows 10 environment), the joycon-python was not able to connect to a Joy-Con.
It was because the `product_string` of a Joy-Con found by `hid.enumerate(0, 0)` was just `Wireless Gamepad`, and not beginning with `Joy-Con`.

This PR removes the check of `product_string`, but I think it is okay because `vendor_id` and `product_id` ensure a device is a Joy-Con.